### PR TITLE
Consider using D1 instead of DO storage

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,6 +40,6 @@ We use three types of storage.
 
 - [R2](https://developers.cloudflare.com/r2/api/workers/workers-api-reference/) for blobs
 - [KV](https://developers.cloudflare.com/workers/runtime-apis/kv/) for metadata and distributed cache
-- [Durable Objects storage](https://developers.cloudflare.com/workers/runtime-apis/durable-objects/#transactional-storage-api) for entities (has own lifecycle such as repositories, blob uploads, etc) state
+- [D1](https://developers.cloudflare.com/d1/) for entities (has own lifecycle such as repositories, blob uploads, etc) state
 
 Still, everything runs on Cloudflare.


### PR DESCRIPTION
Previously, as an implementation strategy for persistent state, I introduced DO and event sourcing.

Also described it may provide better flexibility. And at the time, D1 wasn't such a good option.

I changed my mind after seeing this announcement today.
https://blog.cloudflare.com/d1-turning-it-up-to-11/

It now JSON features and time travel recovery. A very reasonable pricing policy is also included.

What DO still does better is its lower access cost and actor model. It allows for more aggressive distribution model and elasticity if we don't want distributed transactions or something (indeed it is very difficult)

The SQL frontend definetely will provide better DX and operational convenience.

The only blocker is that it doesn't yet provide Rust bindings, but that will probably be there soon.

https://github.com/cloudflare/workers-rs/pull/270